### PR TITLE
RFC: Deprecate array prototype extensions

### DIFF
--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -29,7 +29,7 @@ Continuing in that direction, we should consider recommending the usage of nativ
 
 For convenient methods like `without`, `sortBy`, `uniqBy` etc., the replacement functionality already exists either through generic array functions or utility libraries like [lodash](https://lodash.com), [Ramda](https://ramdajs.com), etc.
 
-For helper functions participating in the Ember classic reactivity system like `pushObject`, `removeObject`, the replacement functionality also already exists in the form of immutable update style with tracked propreties like `@tracked someArray = []`, or through utilizing `TrackedArray` from `tracked-built-ins`.
+For helper functions participating in the Ember classic reactivity system like `pushObject`, `removeObject`, the replacement functionality also already exists in the form of immutable update style with tracked properties like `@tracked someArray = []`, or through utilizing `TrackedArray` from `tracked-built-ins`.
 
 During transition, we still allow users to use `A` from `@ember/array`.
 

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -31,7 +31,7 @@ For convenient methods like `without`, `sortBy`, `uniqBy` etc., the replacement 
 
 For helper functions participating in the Ember classic reactivity system like `pushObject`, `removeObject`, the replacement functionality also already exists in the form of immutable update style with tracked propreties like `@tracked someArray = []`, or through utilizing `TrackedArray` from `tracked-built-ins`.
 
-During transition, we should still allow users to use `A` from `@ember/array`.
+During transition, we still allow users to use `A` from `@ember/array`.
 
 We don't need to build anything new specifically, however, the bulk of the transition will be
 focused on deprecating the array prototype extensions.
@@ -40,13 +40,14 @@ focused on deprecating the array prototype extensions.
 
 An entry to the [Deprecation Guides](https://deprecations.emberjs.com/v4.x) will be added outlining the different recommended transition strategies.
 
-We will create new eslint rule and template lint rule `no-array-prototype-extensions` and set examples. Examples should have recommendations for equivalences.
+Rule `ember/no-array-prototype-extensions` is available for both [eslint](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-array-prototype-extensions.md) and [template lint](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-array-prototype-extensions.md). Rule examples have recommendations for equivalences.
 
-We will also create codemods to help with this migration.
+We can leverage the fixers of lint rule to auto fix some of the issues. We will also create codemods to help with this migration.
 
 ### Convenient methods
 Examples of deprecated and current code:
 ```js
+import Component from '@glimmer/component';
 import { uniqBy, sortBy } from 'lodash';
 
 export default class SampleComponent extends Component{
@@ -72,6 +73,7 @@ export default class SampleComponent extends Component{
 ### Observable based methods
 Examples of deprecated code:
 ```js
+import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class SampleComponent extends Component{
@@ -87,6 +89,7 @@ export default class SampleComponent extends Component{
 Examples of current code. 
 #### Option 1: tracked properties
 ```js
+import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
@@ -102,6 +105,7 @@ export default class SampleComponent extends Component{
 
 #### Option 2: `TrackedArray`
 ```js
+import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { TrackedArray } from 'tracked-built-ins';
@@ -114,6 +118,18 @@ export default class SampleComponent extends Component{
     abc.push(newItem);
   }
 };
+```
+
+### Properties in templates
+Examples of deprecated code:
+
+```hbs
+<Foo @bar={{@list.firstObject.name}} />
+```
+
+Examples of  current code.
+```hbs
+<Foo @bar={{get @list '0.name'}} />
 ```
 
 After the deprecated code is removed from Ember, we need to remove the [options to disable the array prototype extension](https://guides.emberjs.com/v4.2.0/configuring-ember/disabling-prototype-extensions/) from Official Guides and we also need to update the [Tracked Properties](https://guides.emberjs.com/v4.2.0/upgrading/current-edition/tracked-properties/#toc_arrays) `Arrays` section with updated suggestions.

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -1,0 +1,130 @@
+---
+Stage: Initial
+Start Date: 2022-4-01
+Release Date: Unreleased
+Release Versions:
+  ember-source: vX.Y.Z
+  ember-data: vX.Y.Z
+Relevant Team(s): Ember.js
+RFC PR: 
+---
+
+# Deprecate array prototype extensions
+
+## Summary
+
+This RFC proposes to deprecate array prototype extensions.
+
+## Motivation
+
+Ember historically extended the prototypes of native Javascript arrays to implement `Ember.Enumerable`, `Ember.MutableEnumerable`, `Ember.MutableArray`, `Ember.Array`. This added convenient methods and properties, and also made Ember arrays automatically participate in the Ember Classic reactivity system.
+
+Those convenient methods increase the likelihood of becoming potential roadblocks for future built-in language extensions, and make it confusing for users to onboard: is it specifically part of Ember, or Javascript? With Ember Octane, the new reactivity system, those classic observable-based methods are no longer needed.
+
+We had deprecated [Functions](https://github.com/emberjs/rfcs/blob/master/text/0272-deprecation-native-function-prototype-extensions.md) and [Strings](https://github.com/emberjs/rfcs/blob/master/text/0236-deprecation-ember-string.md) prototype extensions. Array is the last step. And internally we had already been preferring generic array methods over prototype extensions ([epic](https://github.com/emberjs/ember.js/issues/15501)).
+
+Continuing in that direction, we should consider recommending the usage of generic array functions as opposed to convenient prototype extension functions, and the usage of new tracked properties over classic reactivity methods.
+
+## Transition Path
+
+For convenient methods like `without`, `sortBy`, `uniqBy` etc., the replacement functionality already exists either through generic array functions or lodash helper functions.
+
+For helper functions participating in the Ember classic reactivity system like `pushObject`, `clear`, the replacement functionality also already exists in the form of immutable update style with tracked propreties like `@tracked someArray = []`, or through utilizing `TrackedArray` from `tracked-built-ins`.
+
+We don't need to build anything new specifically, however, the bulk of the transition will be
+focused on deprecating the array prototype extensions.
+
+## How We Teach This
+
+An entry to the [Deprecation Guides](https://deprecations.emberjs.com/v4.x) will be added outlining the different recommended transition strategies.
+
+We will create a new lint rule `no-array-prototype-extensions` and set examples. Examples should have recommendations for equivalences.
+
+We will also create codemods to help with this migration.
+
+### Convenient methods
+Examples of deprecated and current code:
+```js
+import { set, action } from '@ember/object';
+import { uniqBy, sortBy } from 'lodash';
+
+export default class SampleComponent extends Component{
+  abc = ['x', 'y', 'z', 'x'];
+  
+  // deprecated
+  def = this.abc.without('x');
+  ghi = this.abc.uniq();
+  jkl = this.abc.toArray();
+  mno = this.abc.uniqBy('y');
+  pqr = this.abc.sortBy('z');
+  // ...
+
+  // current
+  def = this.abc.filter(el => el !== 'x');
+  ghi = [...new Set(this.abc)];
+  jkl = [...this.abc];
+  mno = uniqBy(this.abc, 'y');
+  pqr = sortBy(this.abc, 'z');
+};
+```
+
+### Observable based methods
+Examples of deprecated code:
+```js
+import { set, action } from '@ember/object';
+
+export default class SampleComponent extends Component{
+  abc = [];
+
+  @action
+  someAction(newItem) {
+    this.abc.pushObject('1');
+  }
+};
+```
+
+Examples of current code. 
+#### Option 1: tracked properties
+```js
+import { set, action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class SampleComponent extends Component{
+  @tracked abc = [];
+
+  @action
+  someAction(newItem) {
+    this.abc = [...abc, newItem];
+  }
+};
+```
+
+#### Option 2: `TrackedArray`
+```js
+import { set, action } from '@ember/object';
+import { TrackedArray } from 'tracked-built-ins';
+
+export default class SampleComponent extends Component{
+  abc = new TrackedArray();
+
+  @action
+  someAction(newItem) {
+    abc.push(newItem);
+  }
+};
+```
+
+After the deprecated code is removed from Ember, we need to remove the [options to disable the array prototype extension](https://guides.emberjs.com/v4.2.0/configuring-ember/disabling-prototype-extensions/) from Official Guides and we also need to update the [Tracked Properties](https://guides.emberjs.com/v4.2.0/upgrading/current-edition/tracked-properties/#toc_arrays) `Arrays` section with updated suggestions.
+
+## Drawbacks
+- For users relying on Ember array prototype extensions, they will have to refactor their code and use equivalences appropriately.
+- A lot of existing Ember forums/blogs had been assuming the enabling of array prototype extensions which could cause confusions for users referencing them.
+
+
+## Alternatives
+- Continuing allowing array prototype extensions but turning the EXTEND_PROTOTYPES off by default.
+- Do nothing.
+
+### Unresolved questions
+- Some methods like `removeObject`, `removeObjects` that have non-trival logics might require custom helper function in application to ease the migration.
+- Shall we deprecate `Ember.A()` as well or still allowing users to use it?

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -27,7 +27,7 @@ Continuing in that direction, we should consider recommending the usage of nativ
 
 ## Transition Path
 
-For convenient methods like `without`, `sortBy`, `uniqBy` etc., the replacement functionality already exists either through generic array functions or lodash helper functions.
+For convenient methods like `without`, `sortBy`, `uniqBy` etc., the replacement functionality already exists either through generic array functions or utility libraries like [lodash](https://lodash.com), [Ramda](https://ramdajs.com), etc.
 
 For helper functions participating in the Ember classic reactivity system like `pushObject`, `removeObject`, the replacement functionality also already exists in the form of immutable update style with tracked propreties like `@tracked someArray = []`, or through utilizing `TrackedArray` from `tracked-built-ins`.
 

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -138,6 +138,7 @@ After the deprecated code is removed from Ember (at 5.0), we need to remove the 
 - For users relying on Ember array prototype extensions, they will have to refactor their code and use equivalences appropriately.
 - A lot of existing Ember forums/blogs had been assuming the enabling of array prototype extensions which could cause confusions for users referencing them.
 - Increase package sizes, for example, before `this.abc.filterBy('x');`, now `this.abc.filter(el => el !== 'x');`.
+- Although `tracked-built-ins` is on the path to stabilization as an official API via [RFC #812](https://github.com/emberjs/rfcs/pull/812), it is not yet officially recommended and its API may change somewhat between now and stabilization.
 
 ## Alternatives
 - Continuing allowing array prototype extensions but turning the EXTEND_PROTOTYPES off by default.

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -1,6 +1,6 @@
 ---
 Stage: Initial
-Start Date: 2022-6-21
+Start Date: 2022-8-21
 Release Date: Unreleased
 Release Versions:
   ember-source: vX.Y.Z
@@ -40,7 +40,9 @@ An entry to the [Deprecation Guides](https://deprecations.emberjs.com/v4.x) will
 
 Rule `ember/no-array-prototype-extensions` is available for both [eslint](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-array-prototype-extensions.md) and [template lint](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-array-prototype-extensions.md) usages. Rule examples have recommendations for equivalences.
 
-We can leverage the fixers of lint rule to auto fix some of the issues. We will also create codemods to help with this migration.
+We can leverage the fixers of lint rule to auto fix some of the issues, e.g. the built-in [fixer](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-array-prototype-extensions.md) of `firstObject` usages in template. 
+
+We also should create codemods or autofixers in lint rules for some of the convinient functions like `reject`, `compact`, `any` etc.
 
 Examples (taken from [Deprecation Guide](https://github.com/smilland/rfcs/pull/1)): 
 ### Convenient methods
@@ -167,3 +169,10 @@ After the deprecated code is removed from Ember (at 5.0), we need to remove the 
 - Do one of these, but target Ember v6 instead.
 
 - Do nothing.
+
+## Unresolved questions
+- Current lint rule [ember/no-array-prototype-extensions](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-array-prototype-extensions.md) gives a lot of false positives giving the limitation of static analysis.
+- Difficulties for providing stable codemods or autofixers:
+  1. giving false positives on lint rules, same will apply to codemods or autofixers;
+  2. when migrating certain methods, we need to access object. Shall we use Ember `get` or native way? Unless we fully remove ObjectProxy dependency, codemods or autofixers would still require manual work in certain cases.
+  3. observable functions or properties requires manual refactoring;

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -42,7 +42,7 @@ Rule `ember/no-array-prototype-extensions` is available for both [eslint](https:
 
 We can leverage the fixers of lint rule to auto fix some of the issues, e.g. the built-in [fixer](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-array-prototype-extensions.md) of `firstObject` usages in template. 
 
-We also should create codemods or autofixers in lint rules for some of the convinient functions like `reject`, `compact`, `any` etc.
+We also should create codemods or autofixers in lint rules for some of the convinient functions like `reject`, `compact`, `any` etc. More discussions on **Unresolved Questions** section.
 
 Examples (taken from [Deprecation Guide](https://github.com/smilland/rfcs/pull/1)): 
 ### Convenient methods

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -158,5 +158,12 @@ After the deprecated code is removed from Ember (at 5.0), we need to remove the 
 - Although `tracked-built-ins` is on the path to stabilization as an official API via [RFC #812](https://github.com/emberjs/rfcs/pull/812), it is not yet officially recommended and its API may change somewhat between now and stabilization.
 
 ## Alternatives
-- Continuing allowing array prototype extensions but turning the EXTEND_PROTOTYPES off by default.
+- Do the deprecation as suggested here for use within Ember itself, but extract it as a standalone library for users who want to use it. This will only work as long as the underlying Ember Classic reactivity system is supported.
+
+    As a variation on this, we could do this but explicitly only support it up through the first LTS release in the 5.x series.
+
+- Continuing allowing array prototype extensions but turning the `EXTEND_PROTOTYPES` off by default.
+
+- Do one of these, but target Ember v6 instead.
+
 - Do nothing.

--- a/text/0000-deprecate-array-prototype-extensions.md
+++ b/text/0000-deprecate-array-prototype-extensions.md
@@ -132,7 +132,7 @@ Examples of  current code.
 <Foo @bar={{get @list '0.name'}} />
 ```
 
-After the deprecated code is removed from Ember, we need to remove the [options to disable the array prototype extension](https://guides.emberjs.com/v4.2.0/configuring-ember/disabling-prototype-extensions/) from Official Guides and we also need to update the [Tracked Properties](https://guides.emberjs.com/v4.2.0/upgrading/current-edition/tracked-properties/#toc_arrays) `Arrays` section with updated suggestions.
+After the deprecated code is removed from Ember (at 5.0), we need to remove the [options to disable the array prototype extension](https://guides.emberjs.com/v4.2.0/configuring-ember/disabling-prototype-extensions/) from Official Guides and we also need to update the [Tracked Properties](https://guides.emberjs.com/v4.2.0/upgrading/current-edition/tracked-properties/#toc_arrays) `Arrays` section with updated suggestions.
 
 ## Drawbacks
 - For users relying on Ember array prototype extensions, they will have to refactor their code and use equivalences appropriately.


### PR DESCRIPTION
We are moving away from prototype extensions.
[Rendered](https://github.com/smilland/rfcs/blob/92b9401e4f7090a544d98dae52dda65c86a963b2/text/0000-deprecate-array-prototype-extensions.md)